### PR TITLE
fix: PGPool error handling and app.js catch/callback bugs

### DIFF
--- a/greenstand/PGPool.js
+++ b/greenstand/PGPool.js
@@ -41,13 +41,18 @@ class PGPool{
         const resultHandled = handleResult? handleResult(result):result;
         while(this.queue[sql].length > 0){
           const cb = this.queue[sql].pop();
-          cb(resultHandled);
+          cb(null, resultHandled);
         }
         this.cache.set(sql,resultHandled);
         this.isFetching[sql] = false;
         log.warn("fetch finished");
       }).catch(e => {
         log.error("get error when query db:", e);
+        this.isFetching[sql] = false;
+        while(this.queue[sql] && this.queue[sql].length > 0){
+          const cb = this.queue[sql].pop();
+          cb(e, null);
+        }
       });
     }
   }
@@ -65,8 +70,9 @@ class PGPool{
         log.warn("cache bingo!");
         res(value);
       }else{
-        this.fetch(sql, handleResult, (result)=>{
+        this.fetch(sql, handleResult, (err, result)=>{
           log.warn("fetch callback");
+          if(err) return rej(err);
           res(result);
         });
       }

--- a/greenstand/app.js
+++ b/greenstand/app.js
@@ -68,7 +68,7 @@ async function buildMapInstance(x, y, z, params){
     },function(err,_map) {
       if(err){
         log.error("e when fromString:", err);
-        throw "failed";
+        return rej(err);
       }
       //      if (options.bufferSize) {
       //        obj.bufferSize = options.bufferSize;
@@ -106,9 +106,9 @@ try{
   const im = new mapnik.Image(256, 256);
   const buffer = await new Promise((res, rej) => {
     map.render(im, function(err, im) {
-      if(err) throw err;
+      if(err) return rej(err);
       im.encode('png', function(err,buffer) {
-        if (err) throw err;
+        if(err) return rej(err);
         res(buffer);
       });
     });
@@ -118,7 +118,7 @@ try{
   res.end(buffer);
 }catch(e){
   log.error("got error in handler:", e);
-  res.status(500).json({message:"something wrong:" + error});
+  res.status(500).json({message:"something wrong:" + e});
 }
 });
 
@@ -134,13 +134,13 @@ try{
   if(parseInt(z) <= 9){
     fields.push("zoom_to");
   }
-  const json = await new Promise((res, _rej) => {
+  const json = await new Promise((res, rej) => {
     map.render(
       grid, {
         layer:"l1", 
         fields,
       }, function(err, grid) {
-      if (err) throw err;
+      if (err) return rej(err);
       log.debug("grid:",grid);
       const json = grid.encodeSync({resolution: 4, features: true});
       res(json);
@@ -151,7 +151,7 @@ try{
   res.json(json);
 }catch(e){
   log.error("got error in handler:", e);
-  res.status(500).json({message:"something wrong:" + error});
+  res.status(500).json({message:"something wrong:" + e});
 }
 });
 
@@ -165,9 +165,9 @@ app.get("/new/:z/:x/:y.png", async (req, res) => {
     const im = new mapnik.Image(256, 256);
     const buffer = await new Promise((res, rej) => {
       map.render(im, function(err, im) {
-        if(err) throw err;
+        if(err) return rej(err);
         im.encode('png', function(err,buffer) {
-          if (err) throw err;
+          if(err) return rej(err);
           res(buffer);
         });
       });
@@ -177,7 +177,7 @@ app.get("/new/:z/:x/:y.png", async (req, res) => {
     res.end(buffer);
   }catch(e){
     log.error("got error in handler:", e);
-    res.status(500).json({message:"something wrong:" + error});
+    res.status(500).json({message:"something wrong:" + e});
   }
   });
   
@@ -193,13 +193,13 @@ app.get("/new/:z/:x/:y.png", async (req, res) => {
     if(parseInt(z) <= 9){
       fields.push("zoom_to");
     }
-    const json = await new Promise((res, _rej) => {
+    const json = await new Promise((res, rej) => {
       map.render(
         grid, {
           layer:"l1", 
           fields,
         }, function(err, grid) {
-        if (err) throw err;
+        if (err) return rej(err);
         log.debug("grid:",grid);
         const json = grid.encodeSync({resolution: 4, features: true});
         res(json);
@@ -210,7 +210,7 @@ app.get("/new/:z/:x/:y.png", async (req, res) => {
     res.json(json);
   }catch(e){
     log.error("got error in handler:", e);
-    res.status(500).json({message:"something wrong:" + error});
+    res.status(500).json({message:"something wrong:" + e});
   }
   });
 


### PR DESCRIPTION
## What
Fixes four confirmed bugs in `PGPool.js` and `app.js` that cause 
permanent request freezes, memory leaks, unhandled process crashes, 
and broken 500 error responses.

Fixes Bug 1 in issue: https://github.com/Greenstand/treetracker-infrastructure/issues/315
Related to issue: https://github.com/Greenstand/treetracker-infrastructure/issues/300

## Why

**PGPool.js**
- A DB error left `isFetching[sql] = true` permanently, freezing all 
  future requests for that SQL string and leaking queued callbacks
- The `getQuery()` Promise never rejected on DB error — callers hung 
  indefinitely with no error signal

**app.js**
- All 4 route catch blocks referenced undefined `error` instead of 
  caught `e`, causing a `ReferenceError` that prevented 500 responses 
  from being sent
- `throw err` inside non-async `map.render()` and `fromString` 
  callbacks bypassed the outer try/catch, generating unhandled 
  exceptions that crash the Node process

## Change

**PGPool.js**
- Adopted Node.js error-first callback convention `cb(err, result)` 
  on both success and error paths
- catch block now resets `isFetching[sql]` and drains the queue, 
  calling each pending callback with the error
- `getQuery()` consumer updated to handle `(err, result)` and 
  propagate errors via `rej(err)`

**app.js**
- `fromString` callback: replaced `throw "failed"` with `return rej(err)`
- Both grid routes: renamed `_rej` → `rej` to bring rejector into scope
- All render callbacks: replaced `throw err` with `return rej(err)`
- All 4 catch blocks: fixed `error` → `e`

## Follow-up
- Tests for new error paths in `PGPool.js` (fetch failure, queue drain) 
  and `app.js` (rej propagation) to be added in a subsequent PR per 
  CONTRIBUTING.md testing requirements.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update